### PR TITLE
Feat: Multi-plane 3D trap grid + FFT propagation (closes #17)

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -15,7 +15,7 @@ Endpoints:
 """
 from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
-from typing import Optional
+from typing import Optional, List
 
 from ..simulation.trap_manager import TrapManager
 
@@ -149,6 +149,51 @@ async def move_trap(
     manager.generator.move_trap(index, x, y)
     manager.generator.calculate_phase_mask()
     return {"status": "moved", "state": manager.get_state()}
+
+
+class TrapGridConfig(BaseModel):
+    """Configuration for creating a grid of traps.
+
+    Attributes:
+        rows: Number of trap rows (1-10).
+        cols: Number of trap columns (1-10).
+        spacing: Distance between traps in normalized coords (0.05-1.0).
+        z_planes: List of z values for multi-plane arrays. Defaults to [0.0].
+    """
+    rows: int = Field(default=2, ge=1, le=10)
+    cols: int = Field(default=2, ge=1, le=10)
+    spacing: float = Field(default=0.3, gt=0.05, le=1.0)
+    z_planes: Optional[List[float]] = Field(default=None)
+
+
+@router.post("/trap/grid")
+async def add_trap_grid(config: TrapGridConfig):
+    """Add a grid of traps, optionally at multiple z-planes.
+
+    Creates a rectangular array of traps centered at the origin.
+    Recalculates the phase mask after adding all traps.
+
+    Args:
+        config: Grid configuration with rows, cols, spacing, z_planes.
+
+    Returns:
+        Status, number of traps added, iteration count, and full state.
+    """
+    manager = get_manager()
+    if manager is None:
+        return {"error": "Not initialized"}
+    n_before = len(manager.generator.traps)
+    manager.generator.add_trap_grid(
+        config.rows, config.cols, config.spacing, config.z_planes
+    )
+    n_added = len(manager.generator.traps) - n_before
+    iters = manager.generator.calculate_phase_mask()
+    return {
+        "status": "grid_added",
+        "traps_added": n_added,
+        "iterations": iters,
+        "state": manager.get_state(),
+    }
 
 
 @router.get("/state")

--- a/app/simulation/phase_mask.py
+++ b/app/simulation/phase_mask.py
@@ -300,6 +300,29 @@ class PhaseMaskGenerator:
         rho = compute_rho(self.coord_x, self.coord_y, x, y)
         self._rho.append(rho)
 
+    def add_trap_grid(self, rows, cols, spacing=0.3, z_planes=None):
+        """Add a grid of traps, optionally at multiple z-planes.
+
+        Creates a rectangular array of traps centered at the origin.
+        When z_planes is provided, the entire grid is replicated at each
+        z value, enabling 3D trap arrays for multi-plane trapping.
+
+        Args:
+            rows: Number of trap rows.
+            cols: Number of trap columns.
+            spacing: Distance between traps (normalized coords).
+            z_planes: List of z values. If None, uses z=0.
+        """
+        if z_planes is None:
+            z_planes = [0.0]
+
+        for z in z_planes:
+            for r in range(rows):
+                for c in range(cols):
+                    x = (c - (cols - 1) / 2) * spacing
+                    y = (r - (rows - 1) / 2) * spacing
+                    self.add_trap(x, y, z)
+
     def remove_trap(self, index: int):
         """Remove a trap by index.
 
@@ -815,4 +838,8 @@ class PhaseMaskGenerator:
             'uniformity': self.uniformity_history[-1] if self.uniformity_history else 0,
             'uniformity_history': [float(u) for u in self.uniformity_history[-20:]],
             'intensity_preview': intensity_list,
+            'trap_3d_positions': [
+                {'x': float(t.x), 'y': float(t.y), 'z': float(t.z)}
+                for t in self.traps
+            ],
         }

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -116,6 +116,24 @@
                     <button class="action-btn" id="btn-recalculate" title="Force recalculation of the phase mask using the current trap positions">Recalculate</button>
                     <button class="action-btn secondary" id="btn-clear" title="Remove all traps and reset the phase mask">Clear All</button>
                 </div>
+                <div style="margin-top:6px; border-top:1px solid #444; padding-top:6px;">
+                    <strong style="font-size:0.85em;">Add Grid</strong>
+                    <div class="param-row" style="margin-top:2px;">
+                        <label title="Number of rows in the trap grid">Rows</label>
+                        <input type="number" id="grid-rows" value="2" min="1" max="10" step="1" style="width:48px;" title="Number of rows">
+                        <label title="Number of columns in the trap grid">Cols</label>
+                        <input type="number" id="grid-cols" value="2" min="1" max="10" step="1" style="width:48px;" title="Number of columns">
+                    </div>
+                    <div class="param-row" style="margin-top:2px;">
+                        <label title="Spacing between traps in normalized coordinates">Spacing</label>
+                        <input type="number" id="grid-spacing" value="0.3" min="0.05" max="1.0" step="0.05" style="width:60px;" title="Spacing (normalized coords)">
+                    </div>
+                    <div class="param-row" style="margin-top:2px;">
+                        <label title="Comma-separated z-plane values for 3D arrays (e.g. -0.5,0,0.5)">Z planes</label>
+                        <input type="text" id="grid-z-planes" value="0" style="width:100px;" title="Comma-separated z values (e.g. -0.5,0,0.5)">
+                    </div>
+                    <button class="action-btn" id="btn-add-grid" style="margin-top:4px;" title="Add a rectangular grid of traps at the specified z-planes">Add Grid</button>
+                </div>
             </div>
 
             <!-- Parameters -->
@@ -160,7 +178,7 @@
                 <div class="trap-list" style="margin-top: 6px;">
                     <table>
                         <thead>
-                            <tr><th>#</th><th>X</th><th>Y</th><th>Intensity</th></tr>
+                            <tr><th>#</th><th>X</th><th>Y</th><th>Z</th><th>Intensity</th></tr>
                         </thead>
                         <tbody id="trap-list-body">
                         </tbody>

--- a/app/static/js/controls.js
+++ b/app/static/js/controls.js
@@ -17,11 +17,12 @@ class DinHotControls {
      * @param {function} onRecalculate - Callback when recalculate is pressed
      * @param {function} onClearAll - Callback when clear all is pressed
      */
-    constructor(onModeChange, onInit, onRecalculate, onClearAll) {
+    constructor(onModeChange, onInit, onRecalculate, onClearAll, onAddGrid) {
         this.onModeChange = onModeChange;
         this.onInit = onInit;
         this.onRecalculate = onRecalculate;
         this.onClearAll = onClearAll;
+        this.onAddGrid = onAddGrid || function() {};
 
         this.currentMode = 'create';
 
@@ -71,6 +72,14 @@ class DinHotControls {
                 this.onClearAll();
             });
         }
+
+        const gridBtn = document.getElementById('btn-add-grid');
+        if (gridBtn) {
+            gridBtn.addEventListener('click', () => {
+                const gridConfig = this._getGridConfig();
+                this.onAddGrid(gridConfig);
+            });
+        }
     }
 
     /**
@@ -93,6 +102,22 @@ class DinHotControls {
             wavelength_nm: parseFloat(document.getElementById('param-wavelength').value) || 632.0,
             max_iterations: parseInt(document.getElementById('param-max-iter').value) || 50,
             tolerance: parseFloat(document.getElementById('param-tolerance').value) || 1e-6,
+        };
+    }
+
+    /**
+     * Get grid configuration from input fields.
+     * @returns {object} Grid config with rows, cols, spacing, z_planes
+     * @private
+     */
+    _getGridConfig() {
+        const zStr = (document.getElementById('grid-z-planes').value || '0').trim();
+        const zPlanes = zStr.split(',').map(s => parseFloat(s.trim())).filter(v => !isNaN(v));
+        return {
+            rows: parseInt(document.getElementById('grid-rows').value) || 2,
+            cols: parseInt(document.getElementById('grid-cols').value) || 2,
+            spacing: parseFloat(document.getElementById('grid-spacing').value) || 0.3,
+            z_planes: zPlanes.length > 0 ? zPlanes : [0.0],
         };
     }
 
@@ -147,10 +172,12 @@ class DinHotControls {
         tbody.innerHTML = '';
         traps.forEach((trap, i) => {
             const row = document.createElement('tr');
+            const zVal = (trap.z !== undefined && trap.z !== null) ? trap.z.toFixed(2) : '0.00';
             row.innerHTML = `
                 <td>${i}</td>
                 <td>${trap.x.toFixed(3)}</td>
                 <td>${trap.y.toFixed(3)}</td>
+                <td>${zVal}</td>
                 <td>${trap.intensity.toExponential(2)}</td>
             `;
             tbody.appendChild(row);

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -210,5 +210,42 @@ class TestEdgeCases(unittest.TestCase):
         self.assertEqual(len(state['traps']), 0)
 
 
+class TestTrapGridWorkflow(unittest.TestCase):
+    """Test grid trap creation workflow."""
+
+    def test_grid_create_compute_inspect(self):
+        """Create a grid of traps, compute mask, inspect results."""
+        tm = TrapManager(resolution=(64, 64))
+        tm.generator.add_trap_grid(2, 3, spacing=0.3)
+        tm.needs_recalculation = True
+        tm.recalculate_if_needed()
+
+        state = tm.get_state()
+        self.assertEqual(len(state['traps']), 6)
+        self.assertGreater(state['iterations'], 0)
+        for trap in state['traps']:
+            self.assertGreater(trap['intensity'], 0)
+
+    def test_grid_3d_state(self):
+        """3D grid should include trap_3d_positions in state."""
+        tm = TrapManager(resolution=(64, 64))
+        tm.generator.add_trap_grid(2, 2, spacing=0.3, z_planes=[-0.3, 0, 0.3])
+        tm.needs_recalculation = True
+        tm.recalculate_if_needed()
+
+        state = tm.get_state()
+        self.assertEqual(len(state['traps']), 12)
+        self.assertIn('trap_3d_positions', state)
+        self.assertEqual(len(state['trap_3d_positions']), 12)
+
+    def test_grid_then_delete(self):
+        """Should be able to delete traps after adding a grid."""
+        tm = TrapManager(resolution=(64, 64))
+        tm.generator.add_trap_grid(2, 2, spacing=0.3)
+        self.assertEqual(len(tm.generator.traps), 4)
+        tm.generator.remove_trap(0)
+        self.assertEqual(len(tm.generator.traps), 3)
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/tests/test_phase_mask.py
+++ b/tests/test_phase_mask.py
@@ -525,5 +525,66 @@ class TestFFTForwardPropagation(unittest.TestCase):
         print("PASS: test_calculate_uses_fft_for_many_traps")
 
 
+class TestTrapGrid(unittest.TestCase):
+    """Test the add_trap_grid convenience method."""
+
+    def setUp(self):
+        self.gen = PhaseMaskGenerator(resolution=(64, 64), phase_scale=np.pi)
+
+    def test_grid_default_z(self):
+        """Grid with no z_planes should create traps at z=0."""
+        self.gen.add_trap_grid(2, 3, spacing=0.3)
+        self.assertEqual(len(self.gen.traps), 6)
+        for t in self.gen.traps:
+            self.assertAlmostEqual(t.z, 0.0)
+
+    def test_grid_positions(self):
+        """Grid traps should be centered and evenly spaced."""
+        self.gen.add_trap_grid(2, 2, spacing=0.4)
+        xs = sorted([t.x for t in self.gen.traps])
+        ys = sorted([t.y for t in self.gen.traps])
+        self.assertAlmostEqual(xs[0], -0.2)
+        self.assertAlmostEqual(xs[-1], 0.2)
+        self.assertAlmostEqual(ys[0], -0.2)
+        self.assertAlmostEqual(ys[-1], 0.2)
+
+    def test_grid_multi_z_planes(self):
+        """Grid with multiple z-planes should replicate at each z."""
+        self.gen.add_trap_grid(2, 2, spacing=0.3, z_planes=[-0.5, 0.0, 0.5])
+        self.assertEqual(len(self.gen.traps), 12)  # 2*2*3
+        z_vals = sorted(set(t.z for t in self.gen.traps))
+        self.assertAlmostEqual(z_vals[0], -0.5)
+        self.assertAlmostEqual(z_vals[1], 0.0)
+        self.assertAlmostEqual(z_vals[2], 0.5)
+
+    def test_grid_single_trap(self):
+        """1x1 grid should create a single trap at origin."""
+        self.gen.add_trap_grid(1, 1, spacing=0.3)
+        self.assertEqual(len(self.gen.traps), 1)
+        self.assertAlmostEqual(self.gen.traps[0].x, 0.0)
+        self.assertAlmostEqual(self.gen.traps[0].y, 0.0)
+
+    def test_grid_compute_succeeds(self):
+        """Grid traps should produce a valid phase mask."""
+        self.gen.add_trap_grid(2, 2, spacing=0.3)
+        iters = self.gen.calculate_phase_mask()
+        self.assertGreater(iters, 0)
+        for t in self.gen.traps:
+            self.assertGreater(t.intensity, 0)
+
+    def test_trap_3d_positions_in_state(self):
+        """get_state should include trap_3d_positions with x,y,z."""
+        self.gen.add_trap_grid(2, 2, spacing=0.3, z_planes=[-0.5, 0.5])
+        self.gen.calculate_phase_mask()
+        state = self.gen.get_state()
+        self.assertIn('trap_3d_positions', state)
+        self.assertEqual(len(state['trap_3d_positions']), 8)
+        for pos in state['trap_3d_positions']:
+            self.assertIn('x', pos)
+            self.assertIn('y', pos)
+            self.assertIn('z', pos)
+        print("PASS: test_trap_3d_positions_in_state")
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- add_trap_grid(rows, cols, spacing, z_planes) convenience method
- POST /api/trap/grid endpoint
- Frontend: grid inputs + Z column in trap list
- trap_3d_positions in state for 3D visualization
- 9 new tests

@codex Μπορείς να σκεφτείς πώς θα οπτικοποιούσες ένα 3D trap array στο browser; Ένα Three.js scatter plot με σφαίρες σε κάθε (x,y,z) θέση; Πώς θα αντιστοιχούσες τα κανονικοποιημένα [-1,1] σε φυσικές μονάδες; 🇬🇷

**CODE REVIEW ONLY.**
🤖 Generated with [Claude Code](https://claude.ai/claude-code)