### PR TITLE
Feat: Add `?` shortcut, shortcut table, input-guard for help modal

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -491,6 +491,67 @@ html, body {
     color: var(--accent-red);
 }
 
+/* Keyboard-shortcut table inside the help modal */
+.shortcut-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 4px 0 8px 0;
+    font-size: 12px;
+    font-family: var(--font-mono);
+}
+
+.shortcut-table th,
+.shortcut-table td {
+    text-align: left;
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--border-color);
+    color: var(--text-secondary);
+}
+
+.shortcut-table th {
+    color: var(--accent-cyan);
+    font-weight: 600;
+    font-family: var(--font-main);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    font-size: 11px;
+}
+
+.shortcut-table tr:last-child td {
+    border-bottom: none;
+}
+
+.shortcut-table kbd {
+    display: inline-block;
+    min-width: 22px;
+    padding: 1px 6px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-primary);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-bottom-width: 2px;
+    border-radius: 3px;
+    text-align: center;
+}
+
+.shortcut-table .kbd-note {
+    color: var(--text-muted);
+    font-family: var(--font-main);
+    font-size: 11px;
+    margin-left: 4px;
+}
+
+.modal-hint {
+    margin-top: 10px !important;
+    padding: 8px 10px;
+    font-size: 12px;
+    color: var(--text-muted);
+    background: var(--bg-primary);
+    border-left: 2px solid var(--accent-orange);
+    border-radius: 2px;
+}
+
 /* ============================================================
    Responsive adjustments
    ============================================================ */

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -73,6 +73,26 @@
                     a stable solution. The uniformity metric (I<sub>min</sub>/I<sub>max</sub>)
                     quantifies how equal the trap intensities are, with 1.0 being perfect.
                 </p>
+
+                <h3>Keyboard Shortcuts</h3>
+                <table class="shortcut-table">
+                    <thead>
+                        <tr><th>Key / Action</th><th>Effect</th></tr>
+                    </thead>
+                    <tbody>
+                        <tr><td><kbd>?</kbd></td><td>Open this help dialog (disabled while typing in an input)</td></tr>
+                        <tr><td><kbd>Esc</kbd></td><td>Close this help dialog</td></tr>
+                        <tr><td>Click <span class="kbd-note">(Create mode)</span></td><td>Add a new trap at the click location</td></tr>
+                        <tr><td>Click <span class="kbd-note">(Move mode)</span></td><td>Select the nearest trap to drag</td></tr>
+                        <tr><td>Drag <span class="kbd-note">(Move mode)</span></td><td>Reposition the selected trap; recalculation fires on mouse-up</td></tr>
+                        <tr><td>Click <span class="kbd-note">(Delete mode)</span></td><td>Remove the nearest trap within a small radius</td></tr>
+                        <tr><td>Click backdrop</td><td>Close this help dialog (same effect as <kbd>Esc</kbd>)</td></tr>
+                    </tbody>
+                </table>
+                <p class="modal-hint">
+                    Tip: hover any control in the main view to read an inline tooltip
+                    describing what it does and what ranges are expected.
+                </p>
             </div>
         </div>
 
@@ -199,34 +219,10 @@
     </div>
 
     <!-- Scripts (loaded in dependency order) -->
+    <!-- Help-modal toggle (open/close, `?` shortcut, Esc, backdrop) lives in controls.js -->
     <script src="/static/js/websocket.js"></script>
     <script src="/static/js/renderer.js"></script>
     <script src="/static/js/controls.js"></script>
     <script src="/static/js/app.js"></script>
-
-    <!-- Help modal toggle -->
-    <script>
-    (function() {
-        var modal = document.getElementById('help-modal');
-        var btnOpen = document.getElementById('btn-help');
-        var btnClose = document.getElementById('modal-close-btn');
-
-        function openModal() { modal.classList.add('visible'); }
-        function closeModal() { modal.classList.remove('visible'); }
-
-        btnOpen.addEventListener('click', openModal);
-        btnClose.addEventListener('click', closeModal);
-
-        // Close when clicking the backdrop (outside modal-content)
-        modal.addEventListener('click', function(e) {
-            if (e.target === modal) closeModal();
-        });
-
-        // Close on Escape key
-        document.addEventListener('keydown', function(e) {
-            if (e.key === 'Escape' && modal.classList.contains('visible')) closeModal();
-        });
-    })();
-    </script>
 </body>
 </html>

--- a/app/static/js/controls.js
+++ b/app/static/js/controls.js
@@ -29,6 +29,7 @@ class DinHotControls {
         this._bindModeButtons();
         this._bindActionButtons();
         this._bindParamInputs();
+        this._bindHelpModal();
     }
 
     /**
@@ -88,6 +89,57 @@ class DinHotControls {
      */
     _bindParamInputs() {
         // Parameters update on change -- no live binding needed
+    }
+
+    /**
+     * Bind the help modal: header button, close button, backdrop click,
+     * Escape key (always), and `?` shortcut (only when no input/textarea
+     * is focused, so typing `?` inside a field never pops the modal).
+     *
+     * Silent no-op if the modal markup is absent -- keeps this safe to call
+     * from any page that reuses `controls.js` without the help modal.
+     *
+     * @private
+     */
+    _bindHelpModal() {
+        const modal = document.getElementById('help-modal');
+        const btnOpen = document.getElementById('btn-help');
+        const btnClose = document.getElementById('modal-close-btn');
+        if (!modal || !btnOpen) return;
+
+        const openModal = () => modal.classList.add('visible');
+        const closeModal = () => modal.classList.remove('visible');
+        const isOpen = () => modal.classList.contains('visible');
+
+        btnOpen.addEventListener('click', openModal);
+        if (btnClose) btnClose.addEventListener('click', closeModal);
+
+        // Close when clicking the backdrop (target is the modal, not its content).
+        modal.addEventListener('click', (e) => {
+            if (e.target === modal) closeModal();
+        });
+
+        // Guard so `?` pressed inside a text/number input does NOT open the modal.
+        const isTypingInField = () => {
+            const el = document.activeElement;
+            if (!el) return false;
+            const tag = el.tagName;
+            return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' ||
+                   el.isContentEditable === true;
+        };
+
+        document.addEventListener('keydown', (e) => {
+            // `?` on US layouts is `Shift+/`; e.key resolves to '?' directly.
+            if (e.key === '?' && !isTypingInField() && !isOpen()) {
+                e.preventDefault();
+                openModal();
+                return;
+            }
+            if (e.key === 'Escape' && isOpen()) {
+                e.preventDefault();
+                closeModal();
+            }
+        });
     }
 
     /**

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -100,6 +100,24 @@ Below the stats is a table listing each trap's index, (x, y) position, and compu
 
 A small canvas that plots the error metric over iterations from the most recent phase mask computation. The orange line should show a decreasing trend. A green dot at the end indicates that the algorithm converged before reaching the iteration limit.
 
+## Keyboard Shortcuts
+
+The interface is primarily mouse-driven, but a small set of keyboard shortcuts is wired for fast access to help and for closing dialogs.
+
+| Key / Action | Effect |
+|---|---|
+| `?` | Open the help dialog. Suppressed while a text or number input is focused, so typing `?` in a parameter field never pops the modal. |
+| `Esc` | Close the help dialog if it is open. |
+| Click `?` button (header, top-right) | Same as the `?` shortcut. Always works, including while an input is focused. |
+| Click on the modal backdrop | Close the help dialog. Same effect as `Esc`. |
+| Click on the trap canvas (Create mode) | Add a new trap at the clicked location. |
+| Click on the trap canvas (Move mode) | Select the nearest trap; drag to reposition, release to recalculate. |
+| Click on the trap canvas (Delete mode) | Remove the nearest trap within a small radius. |
+
+Hover any control (mode button, parameter input, canvas) to reveal an inline tooltip that describes what it does and the expected value range. Tooltips are rendered by the browser via `title=` attributes -- no custom tooltip library is loaded.
+
+The help dialog itself lists the same shortcut table under the **Keyboard Shortcuts** heading, so you can re-read it at any time without leaving the app.
+
 ## Typical Workflow
 
 1. **Launch the server** and open the browser. The interface loads with default parameters.


### PR DESCRIPTION
## Summary

Completes the UI-helpers contract required by `conventions/project-quality-standards.md`. The help modal and tooltips already shipped in a prior iteration; this PR adds the pieces that were still missing:

- **`?` keyboard shortcut** — opens the help dialog from anywhere in the UI. Pressing `?` inside a text or number input is intentionally suppressed so typing the character into a parameter field never triggers the modal.
- **Dedicated shortcut table** inside the modal, under a new `Keyboard Shortcuts` heading. Uses semantic `<kbd>` chips and contextual notes (e.g. "Click (Move mode)") so the mode-dependent behavior is discoverable.
- **Consolidated wiring** — the inline `<script>` block previously embedded in `index.html` is removed; all UI event binding now lives in `controls.js` via a new `_bindHelpModal()` method, matching the one-class-per-file convention of the `app/static/js/` layout.
- **Documented shortcuts** in `docs/user_guide.md` so the keyboard contract is visible outside the running app.

No new runtime dependencies; everything is vanilla DOM + CSS.

## Test plan

- `python -m pytest tests/ -q` → 90 passed, 1 warning (pre-existing `python_multipart` deprecation).
- Static audit script (run locally):
  - Inline helper script removed from `index.html` (no `btnOpen.addEventListener` in the HTML).
  - Shortcut table markup present with `<kbd>?</kbd>` and `<kbd>Esc</kbd>` rows.
  - `_bindHelpModal`, `isTypingInField`, `e.key === '?'`, and `e.key === 'Escape'` all present in `controls.js`.
  - `.shortcut-table` and `.shortcut-table kbd` rules present in `style.css`.
  - `## Keyboard Shortcuts` section in `docs/user_guide.md` with the `?` and `Esc` rows.
- Tooltip coverage audit: **21/21** interactive controls in `index.html` carry a `title=` attribute (help button, modal close, 3 mode buttons, 5 action buttons, 8 parameter/grid inputs, 3 canvases).

## Notes

- Chose to keep the guard logic as a plain `activeElement` check instead of pulling in a shortcut library. The entire modal helper is ~40 lines of vanilla JS and has no external dependencies.
- The `<kbd>` element is styled inline via CSS so it renders as a real keycap chip without requiring a separate font.
- Left the existing narrative sections of the modal untouched — adding the shortcut table does not remove the prose explanations; both serve different reading patterns (browsing vs. looking up a specific key).

Closes #29.